### PR TITLE
fix: ensure that the SSL_CA variable is defined in all cases

### DIFF
--- a/publisher/modules/Configs.pm
+++ b/publisher/modules/Configs.pm
@@ -42,13 +42,14 @@ const our $OPAL_DB_DSN          => 'DBI:MariaDB:database=' . $OPAL_DB_NAME . ';h
 const our $OPAL_DB_USERNAME     => $ENV{'OPAL_DB_USER'};
 const our $OPAL_DB_PASSWORD     => $ENV{'OPAL_DB_PASSWORD'};
 const our $USE_SSL              => $ENV{'DATABASE_USE_SSL'};
-if (!defined $USE_SSL || $USE_SSL eq '0') {
-    const our $SSL_CA           => '';
+
+our $SSL_CA = '';
+
+if (defined $USE_SSL && $USE_SSL eq '1') {
+    $SSL_CA           = $ENV{'SSL_CA'};
 }
-else {
-    const our $SSL_CA           => $ENV{'SSL_CA'};
-}
-const our $OPAL_DB_SSL_DSN      => 'DBI:MariaDB:database=' . $OPAL_DB_NAME . ';host=' . $OPAL_DB_HOST . ';port=' . $OPAL_DB_PORT . ';mariadb_ssl=1;mariadb_ssl_verify_server_cert=1;mariadb_ssl_ca_file=' . $SSL_CA;
+
+our $OPAL_DB_SSL_DSN      = 'DBI:MariaDB:database=' . $OPAL_DB_NAME . ';host=' . $OPAL_DB_HOST . ';port=' . $OPAL_DB_PORT . ';mariadb_ssl=1;mariadb_ssl_verify_server_cert=1;mariadb_ssl_ca_file=' . $SSL_CA;
 
 # Environment-specific variables
 const our $FRONTEND_ABS_PATH    => '/var/www/html/';


### PR DESCRIPTION
Fixes the following compilation error when `DATABASE_USE_SSL=0`:

```shell
Variable "$SSL_CA" is not imported at /var/www/html/publisher/controls/../modules/Configs.pm line 51.
Global symbol "$SSL_CA" requires explicit package name (did you forget to declare "my $SSL_CA"?) at /var/www/html/publisher/controls/../modules/Configs.pm line 51.
Compilation failed in require at /var/www/html/publisher/controls/announcementControl.pl line 44.
BEGIN failed--compilation aborted at /var/www/html/publisher/controls/announcementControl.pl line 44.
```

Perl constants need to be declared at compile time, not at runtime.