### PR TITLE
fix: make SSL_CA and fedauth env variables optional if not required

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -52,9 +52,9 @@ FIREBASE_ADMIN_KEY_PATH=/app/config/firebase/firebase-admin-key.json
 CLINICAL_REPORTS_PATH=/var/www/html/opaldocuments
 
 # Active Directory Settings
-FEDAUTH_INSTITUTION=06-ciusss-cusm
-FEDAUTH_API_ENDPOINT=https://fedauthfcp.rtss.qc.ca/fedauth/wsapi/login
 AD_ENABLED=0
+# FEDAUTH_INSTITUTION=06-ciusss-cusm
+# FEDAUTH_API_ENDPOINT=https://fedauthfcp.rtss.qc.ca/fedauth/wsapi/login
 
 # set ORMS_ENABLED=0 to disable the functionalities of the ORMS if the hospital has no ORMS
 ORMS_ENABLED=1

--- a/labs/api/classes/DB/OpalDB.php
+++ b/labs/api/classes/DB/OpalDB.php
@@ -26,7 +26,10 @@ class OpalDB
     {
         if(!isset(OpalDB::$instance)){
             $validator = new Validator($_ENV);
-            $validator->required(["OPAL_DB_HOST", "OPAL_DB_PORT", "OPAL_DB_PASSWORD", "OPAL_DB_USER", "DATABASE_USE_SSL", "SSL_CA"]);
+            $validator->required(["OPAL_DB_HOST", "OPAL_DB_PORT", "OPAL_DB_PASSWORD", "OPAL_DB_USER", "DATABASE_USE_SSL"]);
+            if ($_ENV['DATABASE_USE_SSL'] == "1") {
+                $validator->required(["SSL_CA"]);
+            };
             OpalDB::$instance = DB::getDBConnection(
                 $_ENV['OPAL_DB_HOST'],
                 $_ENV['OPAL_DB_PORT'],
@@ -34,7 +37,7 @@ class OpalDB
                 $_ENV['OPAL_DB_USER'],
                 $_ENV['OPAL_DB_PASSWORD'],
                 $_ENV['DATABASE_USE_SSL'],
-                $_ENV['SSL_CA'],
+                $_ENV['SSL_CA'] ?? '',
             );
         }
         return OpalDB::$instance;

--- a/php/config.php
+++ b/php/config.php
@@ -32,8 +32,8 @@ $dotenv->required('NEW_OPALADMIN_HOST_INTERNAL')->notEmpty();
 $dotenv->required('NEW_OPALADMIN_HOST_EXTERNAL')->notEmpty();
 $dotenv->required('NEW_OPALADMIN_TOKEN')->notEmpty();
 // SSL configurations
-$dotenv->required('DATABASE_USE_SSL')->notEmpty();
-if (getenv('DATABASE_USE_SSL')) {
+$dotenv->required('DATABASE_USE_SSL')->isBoolean();
+if ($_ENV['DATABASE_USE_SSL']) {
     $dotenv->required('SSL_CA')->notEmpty();
 }
 // Push notification configurations
@@ -49,9 +49,11 @@ $dotenv->required('FIREBASE_ADMIN_KEY_PATH')->notEmpty();
 // Path configurations
 $dotenv->required('CLINICAL_REPORTS_PATH')->notEmpty();
 // Active Directory configurations
-$dotenv->required('FEDAUTH_INSTITUTION')->notEmpty();
-$dotenv->required('FEDAUTH_API_ENDPOINT')->notEmpty();
-$dotenv->required('AD_ENABLED')->notEmpty();
+$dotenv->required('AD_ENABLED')->isBoolean();
+if ($_ENV['AD_ENABLED']) {
+    $dotenv->required('FEDAUTH_API_ENDPOINT')->notEmpty();
+    $dotenv->required('FEDAUTH_INSTITUTION')->notEmpty();
+}
 # ORMS
 $dotenv->required('ORMS_ENABLED')->isBoolean();
 // Labs configurations


### PR DESCRIPTION
Avoid having to define env variables when they are not needed. This is in line with our other projects.